### PR TITLE
Implement FLAC file support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
+    implementation 'org.jflac:jflac-codec:1.5.2'
+    shadow 'org.jflac:jflac-codec:1.5.2'
+
     // To use this dependency, you need to compile bukkit by yourself
     // See https://www.spigotmc.org/wiki/buildtools/
     // implementation "org.bukkit:craftbukkit:${bukkit_version}"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A Paper fork of henkelmax's Audio Player.
 - Play custom music discs using the Simple Voice Chat API. (The voice chat mod is required on the client and server.)
 - Use ```/customdisc``` or ```/cd``` to create a custom disc. 
 - Music files should go into ```plugins/CustomDiscs/musicdata/```
-- Music files must be in the ```.wav``` or ```.mp3``` format.
+- Music files must be in the ```.wav```, ```.flac```, or ```.mp3``` format.
 - Only custom discs are compatible with hoppers.
 
 Permission Nodes (Required to run the commands. Playing discs does not require a permission.):

--- a/src/main/java/me/Navoei/customdiscsplugin/PlayerManager.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/PlayerManager.java
@@ -11,6 +11,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.jflac.sound.spi.Flac2PcmAudioInputStream;
+import org.jflac.sound.spi.FlacAudioFileReader;
 
 import javax.annotation.Nullable;
 import javax.sound.sampled.*;

--- a/src/main/java/me/Navoei/customdiscsplugin/PlayerManager.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/PlayerManager.java
@@ -121,6 +121,12 @@ public class PlayerManager {
             AudioInputStream convertedInputStream = new MpegFormatConversionProvider().getAudioInputStream(decodedFormat, inputStream);
             finalInputStream = AudioSystem.getAudioInputStream(audioFormat, convertedInputStream);
 
+        } else if (getFileExtension(file.toFile().toString()).equals("flac")) {
+            AudioInputStream inputStream = new FlacAudioFileReader().getAudioInputStream(file.toFile());
+            AudioFormat baseFormat = inputStream.getFormat();
+            AudioFormat decodedFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, baseFormat.getSampleRate(), 16, baseFormat.getChannels(), baseFormat.getChannels() * 2, baseFormat.getFrameRate(), false);
+            AudioInputStream convertedInputStream = new Flac2PcmAudioInputStream(inputStream, decodedFormat, inputStream.getFrameLength());
+            finalInputStream = AudioSystem.getAudioInputStream(audioFormat, convertedInputStream);
         }
 
         assert finalInputStream != null;

--- a/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/CreateCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/CreateCommand.java
@@ -66,7 +66,7 @@ public class CreateCommand extends SubCommand {
                 File getDirectory = new File(CustomDiscs.getInstance().getDataFolder(), "musicdata");
                 File songFile = new File(getDirectory.getPath(), filename);
                 if (songFile.exists()) {
-                    if (getFileExtension(filename).equals("wav") || getFileExtension(filename).equals("mp3"), getFileExtension(filename).equals("flac")) {
+                    if (getFileExtension(filename).equals("wav") || getFileExtension(filename).equals("mp3") || getFileExtension(filename).equals("flac")) {
                         songname = args[1];
                     } else {
                         player.sendMessage(ChatColor.RED + "File is not in wav, flac, or mp3 format!");

--- a/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/CreateCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/CreateCommand.java
@@ -66,10 +66,10 @@ public class CreateCommand extends SubCommand {
                 File getDirectory = new File(CustomDiscs.getInstance().getDataFolder(), "musicdata");
                 File songFile = new File(getDirectory.getPath(), filename);
                 if (songFile.exists()) {
-                    if (getFileExtension(filename).equals("wav") || getFileExtension(filename).equals("mp3")) {
+                    if (getFileExtension(filename).equals("wav") || getFileExtension(filename).equals("mp3"), getFileExtension(filename).equals("flac")) {
                         songname = args[1];
                     } else {
-                        player.sendMessage(ChatColor.RED + "File is not in wav or mp3 format!");
+                        player.sendMessage(ChatColor.RED + "File is not in wav, flac, or mp3 format!");
                         return;
                     }
                 } else {


### PR DESCRIPTION
I have been looking for a plugin to play custom music without resource packs in my server for a very long time but I finally found this one and I like it a lot so I am doing my part and implementing FLAC file support as it is the format I use the most for storing my music collection.

FLAC files have some advantages over WAVE as they are smaller whilst still being bit-perfect. Hence the name Free **Lossless** Audio Codec.

I know that Simple Voice Chat uses a lossy codec to transmit the audio to players however it is convinient not having to transcode my songs to a different format whenever I want to create a custom disc.

Lastly I would like to point out that I am **not** a professional Java developer and it is not my first language so if I made any mistakes or did not follow the best practices please let me know, closes #29.