### PR TITLE
[Minor changes] Cosmetic changes, mostly in the readme for the download section with the usage of quotation marks.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,12 +17,18 @@ A Paper fork of henkelmax's Audio Player. Special thanks to Athar42 for maintain
 - Music files must be in the ```.wav```, ```.flac```, or ```.mp3``` format.
 
 Downloading Files:
-- To download a file use the command ```/cd download <url> <filename.extension>```. The link used to download a file must be a direct link (meaning the file must automatically begin downloading when accessing the link). Files must have the correct extension specified. An UnsupportedAudioFileException will be thrown in the server's console if the file extension is not correct (for example when giving a wav file the mp3 extension). Below is an example of how to use the command and a link to get direct downloads from Google Drive.
-- Example: ```/cd download https://example.com/mysong mysong.mp3```
+- To download a file use the command ```/cd download <url> <filename.extension>```.
+  - The link used to download a file must be a direct link (meaning the file must automatically begin downloading when accessing the link).
+  - Files must have the correct extension specified.
+  - An UnsupportedAudioFileException will be thrown in the server's console if the file extension is not correct (for example when giving a wav file the mp3 extension).
+  - Below is an example of how to use the command and a link to get direct downloads from Google Drive.
+    - Example: ```/cd download "https://example.com/mysong" mysong.mp3```
+    - **To note** : Do not forget to use quotes (") for the URL. Without this, you'll get a command error.
 - Direct Google Drive links: https://lonedev6.github.io/gddl/
 
 Set the range of a disc:
-- To set the active range of a playable disc, just use the command ```/cd range <range>```. The range can be between 1 and the max value set in the config file (default : 256)
+- To set the active range of a playable disc, just use the command ```/cd range <range>```.
+  - The range can be between 1 and the max value set in the config file (default : 256)
 - Example: ```/cd range 100```
 
 Permission Nodes (Required to run the commands. Playing discs does not require a permission.):

--- a/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/SetHornCooldownSubCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/SetHornCooldownSubCommand.java
@@ -28,7 +28,7 @@ public class SetHornCooldownSubCommand extends CommandAPICommand {
 		super("goatcooldown");
 		this.plugin = plugin;
 		
-		this.withFullDescription(NamedTextColor.GRAY + "Set the cooldown for a modified goat horn (range from 1 to "+ this.plugin.hornMaxCooldown +" in ticks).");
+		this.withFullDescription(NamedTextColor.GRAY + "Set the cooldown for a custom goat horn (range from 1 to "+ this.plugin.hornMaxCooldown +" in ticks).");
 		this.withUsage("/cd goatcooldown <range>");
 		this.withPermission("customdiscs.horncooldown");
 


### PR DESCRIPTION
All in the title.

This aim to "fix" a missing typo in the readme file about the download command usage (+ more readable text, was too long :D )