### PR TITLE
The "Folia Update" - 5.1.1 Release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ mod_id=customdiscsplugin
 voicechat_api_version=2.5.31
 command_api_version=10.1.2
 
-plugin_version=5.0
+plugin_version=5.1.1
 maven_group=me.Navoei.customdiscsplugin
 archives_base_name=custom-discs

--- a/readme.md
+++ b/readme.md
@@ -106,16 +106,6 @@ custom-head-distance: 16
 
 # The max distance from which music discs can be heard in blocks.
 custom-head-max-distance: 256
-
-
-# [DO NOT EDIT BELOW THIS LINE - Help configuration]
-# Custom Discs Help Page
-help:
-  - "&8-[&6CustomDiscs v5.1.1 - Help Page&8]-"
-  - "&aAuthor&7: &6Navoei"
-  - "&aContributors&7: &6Athar42 / &6alfw"
-  - "&fGit&0Hub&7: &9&ohttps://github.com/Navoei/CustomDiscs"
-  - "&aDiscord&7: &9&ohttps://discord.gg/YJpqruvZ97"
 ```
 
 Default Lang.yml:

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-# Custom Discs v5.0 for Paper 1.21.7 / 1.21.8
+# Custom Discs v5.1.1 for Paper and Folia 1.21.7 / 1.21.8
 
 > ### ⚠️⚠️⚠️ READ THIS SECTION CAREFULLY! ⚠️⚠️⚠️
-> ### This version introduces some breaking changes and *requires build 9 of PaperMC 1.21.7*.
-> ### Any earlier version of PaperMC is not guaranteed to function and new features may not function at all!
+> ### This version introduces some breaking changes and *requires build 9 of PaperMC 1.21.7 (and 1.21.8 build 2 of Folia)*.
+> ### Any earlier version of PaperMC/Folia are not guaranteed to function and new features may not function at all!
 > ### Please also note that this new release requires you to delete the ```config.yml``` and ```lang.yml``` files (or update them with the new options).
 > ### Without this being done, you could experience issues with this plugin.
 
@@ -49,6 +49,9 @@ Default Config.yml:
 
 # The maximum download size in megabytes.
 max-download-size: 50
+
+# The maximum length the file name (including the file extension) should be when downloaded. Using a too high value could crash the server.
+filename-maximum-length: 100
 
 # The master volume of music discs from 0-1. (You can set values like 0.5 for 50% volume).
 music-disc-volume: 1
@@ -108,7 +111,7 @@ custom-head-max-distance: 256
 # [DO NOT EDIT BELOW THIS LINE - Help configuration]
 # Custom Discs Help Page
 help:
-  - "&8-[&6CustomDiscs v5.0 - Help Page&8]-"
+  - "&8-[&6CustomDiscs v5.1.1 - Help Page&8]-"
   - "&aAuthor&7: &6Navoei"
   - "&aContributors&7: &6Athar42 / &6alfw"
   - "&fGit&0Hub&7: &9&ohttps://github.com/Navoei/CustomDiscs"
@@ -139,6 +142,6 @@ create-custom-goat-cooldown: '&7Your goat horn cooldown is set to: &a"%custom_go
 custom-music-disabled: '&7Custom music discs are disabled in the configuration.'
 custom-head-disabled: '&7Custom player heads are disabled in the configuration.'
 custom-horn-disabled: '&7Custom goat horns are disabled in the configuration.'
+invalid-protocol: '&cOnly HTTP:// and HTTPS:// URL are allowed.'
+invalid-filename-length: '&cThe maximum file name is restricted to %filename_length_value% characters'
 ```
-
-

--- a/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
@@ -18,6 +18,13 @@ import de.maxhenkel.voicechat.api.BukkitVoicechatService;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIBukkitConfig;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Jukebox;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -37,7 +44,9 @@ public final class CustomDiscs extends JavaPlugin {
 	private VoicePlugin voicechatPlugin;
 	private Logger pluginLogger;
     private static boolean debugMode = false;
-	public static YamlConfiguration LANG;
+    private static Component[] helpMessage;
+    private static final LegacyComponentSerializer LegacyComponentAmpersand = LegacyComponentSerializer.legacyAmpersand();
+    public static YamlConfiguration LANG;
 	public static File LANG_FILE;
 	public static boolean musicDiscEnable = true;
 	public static boolean musicDiscPlayingEnable = true;
@@ -55,7 +64,7 @@ public final class CustomDiscs extends JavaPlugin {
 	public float customHeadDistance;
 	public float customHeadMaxDistance;
     public int filename_maximum_length;
-	
+
 	@Override
 	public void onLoad() {
 		CustomDiscs.instance = this;
@@ -103,6 +112,40 @@ public final class CustomDiscs extends JavaPlugin {
 		if (!(musicData.exists())) {
 			musicData.mkdirs();
 		}
+
+        helpMessage = new Component[]{
+                LegacyComponentAmpersand.deserialize("&8-[&6CustomDiscs v"+ this.getPluginMeta().getVersion() +" - Help Page&8]-"),
+                LegacyComponentAmpersand.deserialize("&aAuthor&7: ")
+                        .append(Component.text("Navoei")
+                        .color(TextColor.color(0xd9a334))
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.openUrl("https://github.com/Navoei"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to open Navoei's GitHub page")))),
+                LegacyComponentAmpersand.deserialize("&aContributors&7: ")
+                        .append(Component.text("Athar42")
+                        .color(TextColor.color(0xd9a334))
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.openUrl("https://github.com/Athar42"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to open Athar42's GitHub page"))))
+                        .append(Component.text(" / "))
+                        .append(Component.text("alfw")
+                        .color(TextColor.color(0xd9a334))
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.openUrl("https://github.com/alfw"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to open alfw's GitHub page")))),
+                LegacyComponentAmpersand.deserialize("&fGit&0Hub&7: ")
+                        .append(Component.text("https://github.com/Navoei/CustomDiscs")
+                        .color(NamedTextColor.BLUE)
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.openUrl("https://github.com/Navoei/CustomDiscs"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to open CustomDiscs' GitHub page")))),
+                LegacyComponentAmpersand.deserialize("&aDiscord&7: ")
+                        .append(Component.text("https://discord.gg/YJpqruvZ97")
+                        .color(NamedTextColor.BLUE)
+                        .decorate(TextDecoration.UNDERLINED)
+                        .clickEvent(ClickEvent.openUrl("https://discord.gg/YJpqruvZ97"))
+                        .hoverEvent(HoverEvent.showText(Component.text("Click to join our Discord !"))))
+        };
 		
 		if (service != null) {
 			voicechatPlugin = new VoicePlugin();
@@ -289,4 +332,11 @@ public final class CustomDiscs extends JavaPlugin {
 	 * @return The boolean value of customHeadPlayingEnable.
 	 */
 	public static boolean isCustomHeadPlayingEnable() { return customHeadPlayingEnable; }
+
+    /**
+     * Get the help message.
+     *
+     * @return The text component for the help message.
+     */
+    public static Component[] getHelpMessage() { return helpMessage; }
 }

--- a/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
@@ -54,6 +54,7 @@ public final class CustomDiscs extends JavaPlugin {
 	public static boolean customHeadPlayingEnable = true;
 	public float customHeadDistance;
 	public float customHeadMaxDistance;
+    public int filename_maximum_length;
 	
 	@Override
 	public void onLoad() {
@@ -92,6 +93,7 @@ public final class CustomDiscs extends JavaPlugin {
 		customHeadPlayingEnable = getConfig().getBoolean("custom-head-playing-enable");
 		customHeadDistance = getConfig().getInt("custom-head-distance");
 		customHeadMaxDistance = getConfig().getInt("custom-head-max-distance");
+        filename_maximum_length = getConfig().getInt("filename-maximum-length");
 
 		// Checking server version and display console message in case the server is not supported
         ServerVersionChecker serverVersionChecker = new ServerVersionChecker(this);

--- a/src/main/java/me/Navoei/customdiscsplugin/HopperManager.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/HopperManager.java
@@ -77,18 +77,25 @@ public class HopperManager implements Listener {
             pluginLogger.info("DEBUG - HopperManager -> Enter : onJukeboxEjectToHopper");
         }
 
-        InventoryHolder holderSource = event.getSource().getHolder();
-        InventoryHolder holderDestination = event.getDestination().getHolder();
-
+        if (!TypeChecker.isCustomMusicDisc(event.getItem())) return;
         if (event.getSource().getLocation() == null) return;
         if (!event.getSource().getType().equals(InventoryType.JUKEBOX)) return;
-        if (event.getItem().getItemMeta() == null) return;
-        if (!TypeChecker.isCustomMusicDisc(event.getItem())) return;
 
-        if (holderDestination instanceof HopperMinecart) {
-            playerManager.stopDisc(((BlockState) holderSource).getBlock());
+        if (ServerVersionChecker.isPaperAPI()) {
+            if (!(event.getDestination().getHolder(false) instanceof HopperMinecart)) return;
+
+            InventoryHolder holderSource = event.getSource().getHolder(false);
+            if (holderSource instanceof BlockState) {
+                playerManager.stopDisc(((BlockState) holderSource).getBlock());
+            }
+        } else {
+            if (!(event.getDestination().getHolder() instanceof HopperMinecart)) return;
+
+            InventoryHolder holderSource = event.getSource().getHolder();
+            if (holderSource instanceof BlockState) {
+                playerManager.stopDisc(((BlockState) holderSource).getBlock());
+            }
         }
-
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
@@ -59,9 +59,9 @@ public class ServerVersionChecker {
 
                 // We then perform a version comparison
                 if (compareVersions(cleanVersion, "folia") < 0) {
-                    pluginLogger.severe("This Paper server version is unsupported. Please update to at least Paper " + REQUIRED_FOLIA_VERSION);
+                    pluginLogger.severe("This Folia server version is unsupported. Please update to at least Folia " + REQUIRED_FOLIA_VERSION);
                 } else {
-                    pluginLogger.info("Paper server version is supported.");
+                    pluginLogger.info("Folia server version is supported.");
                 }
             } else {
                 // For Paper forks servers (mostly), log a severe message about non-support

--- a/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
@@ -12,6 +12,7 @@ public class ServerVersionChecker {
     private static final String REQUIRED_FOLIA_VERSION = "1.21.8-2"; // Set the Folia required version
     private final Logger pluginLogger;
     private final boolean debugModeResult = CustomDiscs.isDebugMode();
+    public static boolean paperAPIcheck;
 
     public ServerVersionChecker(JavaPlugin plugin) {
         this.pluginLogger = plugin.getLogger();
@@ -20,6 +21,8 @@ public class ServerVersionChecker {
     public void checkVersion() {
         // Get the full server version message output
         String versionMessage = Bukkit.getVersionMessage();
+
+        paperAPIcheck = false;
 
         if (versionMessage == null) {
             pluginLogger.severe("Unable to detect the running server version. Is this a supported PaperMC release?");
@@ -51,6 +54,7 @@ public class ServerVersionChecker {
                 } else {
                     pluginLogger.info("Paper server version is supported.");
                 }
+                paperAPIcheck = true;
             } else if ("folia".equalsIgnoreCase(serverType)) {
                 String cleanVersion = cleanBuildVersion(buildVersion);
                 if(debugModeResult) {
@@ -63,6 +67,7 @@ public class ServerVersionChecker {
                 } else {
                     pluginLogger.info("Folia server version is supported.");
                 }
+                paperAPIcheck = true;
             } else {
                 // For Paper forks servers (mostly), log a severe message about non-support
                 pluginLogger.severe(serverType + " server detected. No support will be made in case of issues!");
@@ -115,5 +120,12 @@ public class ServerVersionChecker {
 
         return 0;
     }
+
+    /**
+     * Return if it's a Paper API based server (Paper or Folia).
+     *
+     * @return The boolean value of isPaperAPI.
+     */
+    public static boolean isPaperAPI() { return paperAPIcheck; }
 
 }

--- a/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/ServerVersionChecker.java
@@ -8,7 +8,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ServerVersionChecker {
-    private static final String REQUIRED_VERSION = "1.21.7-9"; // Set the PaperMC required version
+    private static final String REQUIRED_PAPER_VERSION = "1.21.7-9"; // Set the PaperMC required version
+    private static final String REQUIRED_FOLIA_VERSION = "1.21.8-2"; // Set the Folia required version
     private final Logger pluginLogger;
     private final boolean debugModeResult = CustomDiscs.isDebugMode();
 
@@ -45,8 +46,20 @@ public class ServerVersionChecker {
                 }
 
                 // We then perform a version comparison
-                if (compareVersions(cleanVersion) < 0) {
-                    pluginLogger.severe("This Paper server version is unsupported. Please update to at least Paper " + REQUIRED_VERSION);
+                if (compareVersions(cleanVersion, "paper") < 0) {
+                    pluginLogger.severe("This Paper server version is unsupported. Please update to at least Paper " + REQUIRED_PAPER_VERSION);
+                } else {
+                    pluginLogger.info("Paper server version is supported.");
+                }
+            } else if ("folia".equalsIgnoreCase(serverType)) {
+                String cleanVersion = cleanBuildVersion(buildVersion);
+                if(debugModeResult) {
+                    pluginLogger.info("DEBUG - Extracted Version: " + cleanVersion);
+                }
+
+                // We then perform a version comparison
+                if (compareVersions(cleanVersion, "folia") < 0) {
+                    pluginLogger.severe("This Paper server version is unsupported. Please update to at least Paper " + REQUIRED_FOLIA_VERSION);
                 } else {
                     pluginLogger.info("Paper server version is supported.");
                 }
@@ -68,10 +81,15 @@ public class ServerVersionChecker {
         return versionParts.length >= 2 ? versionParts[0] + "-" + versionParts[1] : version;
     }
 
-    private static int compareVersions(String runningVersion) {
+    private static int compareVersions(String runningVersion, String serverType) {
         // We first start by separating the main version number from the build number
         String[] currentVersion = runningVersion.split("-");
-        String[] requiredVersion = REQUIRED_VERSION.split("-");
+        String[] requiredVersion;
+        if(serverType.equals("folia")) {
+            requiredVersion = REQUIRED_FOLIA_VERSION.split("-");
+        } else {
+            requiredVersion = REQUIRED_PAPER_VERSION.split("-");
+        }
 
         // Then we compare the base version (sub-function to handle it)
         // If we are in the same main version, we pass to the next check, else we exit (-1 = older release ; 1 = newer release)

--- a/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
@@ -10,6 +10,7 @@ import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.CommandPermission;
 import dev.jorel.commandapi.executors.CommandArguments;
 
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -38,10 +39,9 @@ public class CustomDiscCommand extends CommandAPICommand {
 	}
 	
 	private int onCommandPlayer(Player player, CommandArguments arguments) {
-		FileConfiguration config = this.plugin.getConfig();
-		for (String message : config.getStringList("help")) {
-			player.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(message));
-		}
+        for (Component message : CustomDiscs.getHelpMessage()) {
+            player.sendMessage(message);
+        }
 		
 		return 1;
 	}

--- a/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
@@ -17,13 +17,11 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 public class CustomDiscCommand extends CommandAPICommand {
-	private final CustomDiscs plugin;
-	
-	public CustomDiscCommand(CustomDiscs plugin) {
+
+    public CustomDiscCommand(CustomDiscs plugin) {
 		super("customdisc");
-		this.plugin = plugin;
-		
-		this.withAliases("cd");
+
+        this.withAliases("cd");
 		this.withFullDescription("The custom discs command.");
 		this.withPermission(CommandPermission.NONE);
 

--- a/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/CustomDiscCommand.java
@@ -11,11 +11,9 @@ import dev.jorel.commandapi.CommandPermission;
 import dev.jorel.commandapi.executors.CommandArguments;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
 public class CustomDiscCommand extends CommandAPICommand {

--- a/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/DownloadSubCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/DownloadSubCommand.java
@@ -51,12 +51,21 @@ public class DownloadSubCommand extends CommandAPICommand {
 	private int onCommandPlayer(Player player, CommandArguments arguments) {
 		final Logger pluginLogger = plugin.getLogger();
 
-		Bukkit.getScheduler().runTaskAsynchronously(this.plugin, () -> {
+        Bukkit.getGlobalRegionScheduler().run(this.plugin, scheduledTask ->  {
 			try {
 				try {
 					URI uri = new URI(Objects.requireNonNull(arguments.getByClass("url", String.class)));
+                    if (!uri.getScheme().equalsIgnoreCase("http") && !uri.getScheme().equalsIgnoreCase("https")) {
+                        player.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(Lang.PREFIX + Lang.INVALID_PROTOCOL.toString()));
+                        return;
+                    }
 					URL fileURL = uri.toURL();
-					String filename = Objects.requireNonNull(arguments.getByClass("filename", String.class));
+
+                    String filename = Objects.requireNonNull(arguments.getByClass("filename", String.class));
+                    if (filename.length() > this.plugin.filename_maximum_length) {
+                        player.sendMessage(LegacyComponentSerializer.legacyAmpersand().deserialize(Lang.PREFIX + Lang.INVALID_FILENAME_LENGTH.toString().replace("%filename_length_value%", Integer.toString(this.plugin.filename_maximum_length))));
+                        return;
+                    }
 
 					if(debugModeResult) {
 						pluginLogger.info("DEBUG - Download File URL: " + fileURL);

--- a/src/main/java/me/Navoei/customdiscsplugin/event/HeadPlay.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/event/HeadPlay.java
@@ -94,8 +94,8 @@ public class HeadPlay implements Listener{
         PersistentDataContainer itemPDC = meta.getPersistentDataContainer();
         if (!itemPDC.has(new NamespacedKey(customDiscs, "customhead"), PersistentDataType.STRING)) return;
 
-        Bukkit.getScheduler().runTaskLater(customDiscs, () -> {
-            Block block = event.getBlockPlaced();
+        Block block = event.getBlockPlaced();
+        Bukkit.getRegionScheduler().runDelayed(customDiscs, block.getLocation(), task -> {
             if (block.getType() != Material.PLAYER_HEAD && block.getType() != Material.PLAYER_WALL_HEAD) return;
 
             Skull skull = (Skull) block.getState();

--- a/src/main/java/me/Navoei/customdiscsplugin/language/Lang.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/language/Lang.java
@@ -4,27 +4,29 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 public enum Lang {
     PREFIX("prefix", "&8[&6CustomDiscs&8]&r"),
-    INVALID_FILENAME("invalid-filename", "&rThis is an invalid filename!"),
-    INVALID_FORMAT("invalid-format", "&rFile must be in wav, flac, or mp3 format!"),
-    FILE_NOT_FOUND("file-not-found", "&rFile not found!"),
-    NOT_HOLDING_CORRECT_ITEM("not-holding-correct-item", "&rYou must either hold a disc, goat horn or player head in your main hand."),
+    INVALID_FILENAME("invalid-filename", "&cThis is an invalid filename!"),
+    INVALID_FORMAT("invalid-format", "&cFile must be in wav, flac, or mp3 format!"),
+    FILE_NOT_FOUND("file-not-found", "&cFile not found!"),
+    NOT_HOLDING_CORRECT_ITEM("not-holding-correct-item", "&cYou must either hold a disc, goat horn or player head in your main hand."),
     CREATE_FILENAME("create-filename", "&7Your filename is: &a\"%filename%\"."),
     CREATE_CUSTOM_NAME("create-custom-name", "&7Your custom name is: &a\"%custom_name%\"."),
     DOWNLOADING_FILE("downloading-file", "&7Downloading file..."),
-    FILE_TOO_LARGE("file-too-large", "&rThe file is larger than %max_download_size%MB."),
+    FILE_TOO_LARGE("file-too-large", "&cThe file is larger than %max_download_size%MB."),
     SUCCESSFUL_DOWNLOAD("successful-download", "&aFile successfully downloaded to &7%file_path%&a."),
     CREATE_DISC("create-disc", "&aCreate a disc by doing &7/cd create filename.extension \"Custom Lore\"&a."),
-    DOWNLOAD_ERROR("download-error", "&rAn error has occurred while downloading."),
+    DOWNLOAD_ERROR("download-error", "&cAn error has occurred while downloading."),
     NOW_PLAYING("now-playing","&6Now playing: %song_name%"),
     DISC_CONVERTED("disc-converted", "&aConverted disc to new format! &fThis is due to changes in newer Minecraft versions which introduced &ToolTipDisplay&f."),
-    INVALID_RANGE("invalid-range","&rYou need to chose a range between 1 and %range_value%"),
+    INVALID_RANGE("invalid-range","&cYou need to chose a range between 1 and %range_value%"),
     CREATE_CUSTOM_RANGE("create-custom-range", "&7Your range is set to: &a\"%custom_range%\"."),
     NOT_HOLDING_CUSTOM_GOAT_HORN("not-holding-custom-goathorn", "&cYou must hold a custom goat horn in your main hand."),
     INVALID_COOLDOWN("invalid-cooldown","&cYou need to chose a cooldown between 1 and %cooldown_value% (in ticks)."),
     CREATE_CUSTOM_GOAT_COOLDOWN("create-custom-goat-cooldown", "&7Your goat horn cooldown is set to: &a\"%custom_goat_cooldown%\" ticks."),
     CUSTOM_MUSIC_DISABLED("custom-music-disabled", "&7Custom music discs are disabled in the configuration."),
     CUSTOM_HEAD_DISABLED("custom-head-disabled", "&7Custom player heads are disabled in the configuration."),
-    CUSTOM_HORN_DISABLED("custom-horn-disabled", "&7Custom goat horns are disabled in the configuration.");
+    CUSTOM_HORN_DISABLED("custom-horn-disabled", "&7Custom goat horns are disabled in the configuration."),
+    INVALID_PROTOCOL("invalid-protocol", "&cOnly HTTP:// and HTTPS:// URL are allowed."),
+    INVALID_FILENAME_LENGTH("invalid-filename-length", "&cThe maximum file name is restricted to %filename_length_value% characters.");
 
     private final String path;
     private final String def;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -59,13 +59,3 @@ custom-head-distance: 16
 
 # The max distance from which music discs can be heard in blocks.
 custom-head-max-distance: 256
-
-
-# [DO NOT EDIT BELOW THIS LINE - Help configuration]
-# Custom Discs Help Page
-help:
-  - "&8-[&6CustomDiscs v5.1.1 - Help Page&8]-"
-  - "&aAuthor&7: &6Navoei"
-  - "&aContributors&7: &6Athar42 / &6alfw"
-  - "&fGit&0Hub&7: &9&ohttps://github.com/Navoei/CustomDiscs"
-  - "&aDiscord&7: &9&ohttps://discord.gg/YJpqruvZ97"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,9 @@
 # The maximum download size in megabytes.
 max-download-size: 50
 
+# The maximum length the file name (including the file extension) should be when downloaded. Using a too high value could crash the server.
+filename-maximum-length: 100
+
 # The master volume of music discs from 0-1. (You can set values like 0.5 for 50% volume).
 music-disc-volume: 1
 
@@ -61,7 +64,7 @@ custom-head-max-distance: 256
 # [DO NOT EDIT BELOW THIS LINE - Help configuration]
 # Custom Discs Help Page
 help:
-  - "&8-[&6CustomDiscs v5.0 - Help Page&8]-"
+  - "&8-[&6CustomDiscs v5.1.1 - Help Page&8]-"
   - "&aAuthor&7: &6Navoei"
   - "&aContributors&7: &6Athar42 / &6alfw"
   - "&fGit&0Hub&7: &9&ohttps://github.com/Navoei/CustomDiscs"

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -20,3 +20,5 @@ create-custom-goat-cooldown: '&7Your goat horn cooldown is set to: &a"%custom_go
 custom-music-disabled: '&7Custom music discs are disabled in the configuration.'
 custom-head-disabled: '&7Custom player heads are disabled in the configuration.'
 custom-horn-disabled: '&7Custom goat horns are disabled in the configuration.'
+invalid-protocol: '&cOnly HTTP:// and HTTPS:// URL are allowed.'
+invalid-filename-length: '&cThe maximum file name is restricted to %filename_length_value% characters'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,3 +16,4 @@ dependencies:
       load: BEFORE
       required: true
       join-classpath: true
+folia-supported: true


### PR DESCRIPTION
This update add Folia server support (1.21.8 required).

This update also require the regen of the config.yml and lang.yml file **OR** to add the new entries which are :

For config.yml : 
```
# The maximum length the file name (including the file extension) should be when downloaded. Using a too high value could crash the server.
filename-maximum-length: 100
```

For lang.yml : 
```
invalid-protocol: '&cOnly HTTP:// and HTTPS:// URL are allowed.'
invalid-filename-length: '&cThe maximum file name is restricted to %filename_length_value% characters'
```


This update also securize the download function a little more 🙃

--- New addition : Code optimization on inventory movements detection.
Thanks to "Jester Man" who reported this on Discord <3

Release tested with success on : 
Paper 1.21.8-42
Folia 1.21.8-3