### PR TITLE
Little fix for async download (thanks to "Jester" for reporting it) + Readme change + new config for CommandAPI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Custom Discs v5.1.1 for Paper and Folia 1.21.7 / 1.21.8
+# Custom Discs v5.1.2 for Paper and Folia 1.21.7 / 1.21.8
 A Paper fork of henkelmax's Audio Player. Special thanks to Athar42 for maintaining this plugin. 
 - Play custom music discs, goat horns and player heads using the Simple Voice Chat API. (The voice chat mod is required on the client and server.)
 - Use ```/customdisc``` or ```/cd``` to view available commands.
@@ -29,8 +29,25 @@ Permission Nodes (Required to run the commands. Playing discs does not require a
 - ```customdiscs.horncooldown``` to set the cooldown (in ticks) for custom goat horns
 
 Dependencies:
-- This plugin depends on the latest version of ProtocolLib available for your Paper version and SimpleVoiceChatBukkit (latest is recommended - at least version 2.5.31 required). 
+- This plugin depends on the latest version of ProtocolLib available for your Paper version and SimpleVoiceChatBukkit (latest is recommended - at least version 2.6.1 required). 
 
+
+Versions support matrix :
+
+| Minecraft version                  | Server type     | Compatible versions          | Latest compatible<br>version                                       |
+|------------------------------------|-----------------|------------------------------|--------------------------------------------------------------------|
+| **1.19**                           | Paper           | 1.1.0 - 2.1                  | [2.1](https://github.com/Navoei/CustomDiscs/releases/tag/v2.1)     |
+| **1.19.1, 1.19.2, 1.19.3**         | Paper           | 2.2 - 2.2.3                  | [2.2.3](https://github.com/Navoei/CustomDiscs/releases/tag/v2.2.3) |
+| **1.19.4**                         | Paper           | 2.3 - 2.3.2                  | [2.3.2](https://github.com/Navoei/CustomDiscs/releases/tag/v2.3.2) |
+| **1.20, 1.20.1**                   | Paper           | 2.4 - 2.4.1                  | [2.4.1](https://github.com/Navoei/CustomDiscs/releases/tag/v2.4.1) |
+| **1.20.2**                         | Paper           | 2.5 - 2.5.1                  | [2.5.1](https://github.com/Navoei/CustomDiscs/releases/tag/v2.5.1) |
+| **1.20.3, 1.20.4, 1.20.5, 1.20.6** | Paper           | 2.6 - 2.6.1                  | [2.6.1](https://github.com/Navoei/CustomDiscs/releases/tag/v2.6.1) |
+| **1.21, 1.21.1**                   | Paper           | 3.0                          | [3.0](https://github.com/Navoei/CustomDiscs/releases/tag/v3.0)     |
+| **1.21.2, 1.21.3**                 | Paper           | 4.1                          | [4.1](https://github.com/Navoei/CustomDiscs/releases/tag/v4.1)     |
+| **1.21.4**                         | Paper           | 4.2 - 4.4                    | [4.4](https://github.com/Navoei/CustomDiscs/releases/tag/v4.4)     |
+| **1.21.5**                         | Paper           | 4.4                          | [4.4](https://github.com/Navoei/CustomDiscs/releases/tag/v4.4)     |
+| **1.21.6, 1.21.7-8**               | Paper           | 4.5                          | [4.5](https://github.com/Navoei/CustomDiscs/releases/tag/v4.5)     |
+| **1.21.7-9, 1.21.8**<br>**1.21.8** | Paper<br>Folia  | 5.0 - 5.1.2<br>5.1.1 - 5.1.2 | [5.1.2](https://github.com/Navoei/CustomDiscs/releases/tag/v5.1.2) |
 
 https://user-images.githubusercontent.com/64107368/178426026-c454ac66-5133-4f3a-9af9-7f674e022423.mp4
 

--- a/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/CustomDiscs.java
@@ -69,9 +69,19 @@ public final class CustomDiscs extends JavaPlugin {
 	@Override
 	public void onLoad() {
 		CustomDiscs.instance = this;
-		CommandAPI.onLoad(new CommandAPIBukkitConfig(this).verboseOutput(true));
-		//To get CommandAPI working on newer MC Release - for development
-		//CommandAPI.onLoad(new CommandAPIBukkitConfig(this).verboseOutput(true).beLenientForMinorVersions(true));
+
+        File commandAPIConfigFile = new File(getDataFolder(), "config_commandapi.yml");
+        if (!commandAPIConfigFile.exists()) {
+            saveResource("config_commandapi.yml", false);
+        }
+        YamlConfiguration retrieveCommandAPIConfig = YamlConfiguration.loadConfiguration(commandAPIConfigFile);
+        boolean isLenient = retrieveCommandAPIConfig.getBoolean("lenientForMinorVersions", false);
+        if (isLenient) {
+            CommandAPI.onLoad(new CommandAPIBukkitConfig(this).verboseOutput(true).beLenientForMinorVersions(true));
+        } else {
+            CommandAPI.onLoad(new CommandAPIBukkitConfig(this).verboseOutput(true));
+        }
+
 		new CustomDiscCommand(this).register("customdiscs");
 	}
 	

--- a/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/DownloadSubCommand.java
+++ b/src/main/java/me/Navoei/customdiscsplugin/command/SubCommands/DownloadSubCommand.java
@@ -51,7 +51,7 @@ public class DownloadSubCommand extends CommandAPICommand {
 	private int onCommandPlayer(Player player, CommandArguments arguments) {
 		final Logger pluginLogger = plugin.getLogger();
 
-        Bukkit.getGlobalRegionScheduler().run(this.plugin, scheduledTask ->  {
+        Bukkit.getAsyncScheduler().runNow(this.plugin, scheduledTask ->  {
 			try {
 				try {
 					URI uri = new URI(Objects.requireNonNull(arguments.getByClass("url", String.class)));

--- a/src/main/resources/config_commandapi.yml
+++ b/src/main/resources/config_commandapi.yml
@@ -1,0 +1,6 @@
+# [Embedded CommandAPI Config]
+
+# Setting this to "true" would allow the internal CommandAPI to run on unsupported server versions.
+# If NMS internals has changed, even setting this to "true", the plugin may not load properly.
+# A concrete example of this would be having the 1.21.6 compatible plugin but using the 1.21.7 or 1.21.8 server release with an older CommandAPI embedded version.
+lenientForMinorVersions: false


### PR DESCRIPTION
I let you decide if you want the CommandAPI config or not (usefull for me, as it avoid me to test in recompiling it with or without it enabled on newer MC release 😂 - Can also be use as a workaround by users on minor server upgrades (like 1.21.6/.7/.8 where CommandAPI did required an updated version, but the "lenient" option was enough to bypass the version check and work)

- Fix the download scheduler to be asynchronous and not synchronous (which will get the server main thread to be stuck. Thanks to "Jester Man" for the report)

- Update the ReadMe to include a support version matrix

- Add a config file (used only for the onLoad method) that'll select the CommandAPI loading option (with or without LenientForMinorVersions) This is usefull between minor fix release (like 1.21.6/.7/.8 where NMS wasn't touched but CommandAPI was blocking the loading as the version was unknown. This setting is set to "false" by default to keep the normal behavior.